### PR TITLE
Create ec2.tf

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,84 @@
+variable "ami_id" {
+  description = "AMI ID to use for the EC2 instance"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet where the EC2 instance will be created"
+  type        = string
+}
+
+variable "key_name" {
+  description = "Optional SSH key pair name"
+  type        = string
+  default     = null
+}
+
+variable "instance_name" {
+  description = "Name tag for the EC2 instance"
+  type        = string
+  default     = "m5-xlarge-ec2"
+}
+
+resource "aws_security_group" "ec2_sg" {
+  name        = "ec2-basic-sg"
+  description = "Basic EC2 security group"
+  vpc_id      = data.aws_subnet.selected.vpc_id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "ec2-basic-sg"
+  }
+}
+
+data "aws_subnet" "selected" {
+  id = var.subnet_id
+}
+
+resource "aws_instance" "this" {
+  ami                         = var.ami_id
+  instance_type               = "m5.xlarge"
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [aws_security_group.ec2_sg.id]
+  key_name                    = var.key_name
+  associate_public_ip_address = true
+
+  tags = {
+    Name = var.instance_name
+  }
+}
+
+output "instance_id" {
+  value = aws_instance.this.id
+}
+
+output "public_ip" {
+  value = aws_instance.this.public_ip
+}
+
+output "private_ip" {
+  value = aws_instance.this.private_ip
+}


### PR DESCRIPTION
<!-- ai-pr-description:start -->
## Summary
- Adds a new Terraform configuration for provisioning an EC2 instance.
- Introduces variables for AMI, subnet, SSH key, and instance naming.
- Sets up a security group with open ingress for SSH and HTTP.
- Outputs EC2 instance details (ID, public/private IP).

## Changes
- Created `terraform/ec2.tf` defining an AWS EC2 instance resource.
- Added a security group allowing SSH (22) and HTTP (80) from any IP.
- Defined variables for AMI ID, subnet ID, key name, and instance name.
- Outputs instance ID, public IP, and private IP.

## Risk
Low. The change is isolated to new Terraform infrastructure code and does not modify existing resources. However, open ingress rules may expose the EC2 instance to the public internet.

## Costs
Increase. Provisioning an `m5.xlarge` EC2 instance will incur compute costs, and public IP assignment may add network charges. Security group rules allowing HTTP/SSH may increase exposure and potential usage.

## Testing
- Run `terraform plan` to verify resource creation and variable handling.
- Apply in a test environment and confirm EC2 instance is provisioned.
- Validate SSH and HTTP access to the instance.
- Check output values for correctness.

## Security
- **HIGH**: Security group allows SSH (22) and HTTP (80) from `0.0.0.0/0` (public internet). This exposes the EC2 instance to potential attacks.
- None found regarding IAM, secrets, or service account permissions.

## Notes
- None.
<!-- ai-pr-description:end -->
